### PR TITLE
update URI for password change email to use fuel_path

### DIFF
--- a/fuel/modules/fuel/models/Fuel_users_model.php
+++ b/fuel/modules/fuel/models/Fuel_users_model.php
@@ -811,7 +811,7 @@ class Fuel_users_model extends Base_module_model {
 
 		if ($this->_is_invite()) {
 
-			$msg = lang('new_user_email', $user_name, '<a href="'.site_url().'fuel/login/reset/'.$token.'">'.site_url().'fuel/login/reset/'.$token.'</a>');
+			$msg = lang('new_user_email', $user_name, '<a href="'.site_url().$CI->fuel->config('fuel_path').'fuel/login/reset/'.$token.'">'.site_url().'fuel/login/reset/'.$token.'</a>');
 
 			$params['to'] = $CI->input->post('email');
 			$params['subject'] = lang('new_user_email_subject');


### PR DESCRIPTION
When the fuel_path is set to something other than 'admin' we'll need the URI sent in password updates to include that value